### PR TITLE
Wine & Winery Reviews

### DIFF
--- a/frontend/src/app/_services/wine.service.ts
+++ b/frontend/src/app/_services/wine.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
-import { Options, Wine } from '../_types';
+import { Options, Wine, WineReview } from '../_types';
 
 import { environment } from 'src/environments/environment';
 import { Response } from '../_types';
@@ -61,6 +61,21 @@ export class WineService {
   }
   delete(wine: Wine) {
     alert("delete wine: " + JSON.stringify(wine));
+  }
+  review(rating: WineReview): Observable<boolean> {
+    return this.http.post(environment.apiEndpoint, {
+      api_key: 'fuck you',
+      type: 'insertReviewWines',
+      target: {
+        user_id: 1,
+        wine_id: rating.wine_id
+      },
+      values: {
+        points: rating.points,
+        review: rating.review,
+        drunk: rating.drunk
+      }
+    }).pipe(map(() => true));
   }
 
   getTopWines(options?: Options<Wine>): Observable<Wine[]> {

--- a/frontend/src/app/_services/winery.service.ts
+++ b/frontend/src/app/_services/winery.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { Options, Response, Winery } from '../_types';
+import { Options, Response, Winery, WineryReview } from '../_types';
 
 
 @Injectable({
@@ -111,6 +111,21 @@ export class WineryService {
       api_key: 'fuck you',
       type: 'deleteWinery',
       winery_id: winery.winery_id
+    }).pipe(map(() => true));
+  }
+
+  review(rating: WineryReview): Observable<boolean> {
+    return this.http.post(environment.apiEndpoint, {
+      api_key: 'fuck you',
+      type: 'insertReviewWinery',
+      target: {
+        user_id: 1,
+        winery_id: rating.winery_id
+      },
+      values: {
+        points: rating,
+        review: rating.review
+      }
     }).pipe(map(() => true));
   }
 

--- a/frontend/src/app/_shared/review-wine/review-wine.component.html
+++ b/frontend/src/app/_shared/review-wine/review-wine.component.html
@@ -1,0 +1,30 @@
+<div class="dialog">
+  <div class="top-bar">
+    <h2 mat-dialog-title>Review {{data.name}}</h2>
+    <button mat-icon-button (click)="onCancel()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <div mat-dialog-content class="content">
+    <h3>Rating</h3>
+    <mat-slider thumbLabel min="1" max="10" step="1">
+      <input matSliderThumb [(ngModel)]="rating">
+    </mat-slider>
+    <h3>Review</h3>
+    <mat-form-field appearance="fill">
+      <mat-label>Review</mat-label>
+      <textarea matInput [(ngModel)]="review"></textarea>
+    </mat-form-field>
+    <mat-checkbox
+      [(ngModel)]="drunk"
+    >
+      Drunk
+    </mat-checkbox>
+  </div>
+
+  <div class="actions" mat-dialog-actions align="end">
+    <button mat-flat-button color="primary" (click)="onReview()">Review</button>
+  </div>
+
+</div>

--- a/frontend/src/app/_shared/review-wine/review-wine.component.sass
+++ b/frontend/src/app/_shared/review-wine/review-wine.component.sass
@@ -1,0 +1,24 @@
+.top-bar
+  display: flex
+  align-items: start
+
+.top-bar h2
+  flex-grow: 1
+
+.dialog
+  width: 75vw
+
+.dialog .content
+  width: 100%
+  display: flex
+  flex-direction: column
+
+mat-slider
+  margin-left: 3rem
+  margin-right: 3rem
+
+text-area
+  height: 20rem
+
+.actions button
+  width: fit-content

--- a/frontend/src/app/_shared/review-wine/review-wine.component.ts
+++ b/frontend/src/app/_shared/review-wine/review-wine.component.ts
@@ -1,0 +1,34 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Wine, WineReview } from 'src/app/_types';
+
+@Component({
+  selector: 'app-review-wine',
+  templateUrl: './review-wine.component.html',
+  styleUrls: ['./review-wine.component.sass']
+})
+export class ReviewWineComponent {
+  rating: number = 1;
+  review: string = "";
+  drunk: boolean = false;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: Wine,
+    private dialogRef: MatDialogRef<ReviewWineComponent>
+  ) {
+
+  }
+  onCancel() {
+    this.dialogRef.close();
+  }
+  onReview() {
+    const data: WineReview = {
+      points: this.rating,
+      review: this.review,
+      wine_id: this.data.wine_id,
+      drunk: this.drunk
+    }
+    this.dialogRef.close(data);
+  }
+
+}

--- a/frontend/src/app/_shared/review-winery/review-winery.component.html
+++ b/frontend/src/app/_shared/review-winery/review-winery.component.html
@@ -1,0 +1,25 @@
+<div class="dialog">
+  <div class="top-bar">
+    <h2 mat-dialog-title>Review {{data.name}}</h2>
+    <button mat-icon-button (click)="onCancel()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <div mat-dialog-content class="content">
+    <h3>Rating</h3>
+    <mat-slider thumbLabel min="1" max="10" step="1">
+      <input matSliderThumb [(ngModel)]="rating">
+    </mat-slider>
+    <h3>Review</h3>
+    <mat-form-field appearance="fill">
+      <mat-label>Review</mat-label>
+      <textarea matInput [(ngModel)]="review"></textarea>
+    </mat-form-field>
+  </div>
+
+  <div class="actions" mat-dialog-actions align="end">
+    <button mat-flat-button color="primary" (click)="onReview()">Review</button>
+  </div>
+
+</div>

--- a/frontend/src/app/_shared/review-winery/review-winery.component.sass
+++ b/frontend/src/app/_shared/review-winery/review-winery.component.sass
@@ -1,0 +1,24 @@
+.top-bar
+  display: flex
+  align-items: start
+
+.top-bar h2
+  flex-grow: 1
+
+.dialog
+  width: 75vw
+
+.dialog .content
+  width: 100%
+  display: flex
+  flex-direction: column
+
+mat-slider
+  margin-left: 3rem
+  margin-right: 3rem
+
+text-area
+  height: 20rem
+
+.actions button
+  width: fit-content

--- a/frontend/src/app/_shared/review-winery/review-winery.component.ts
+++ b/frontend/src/app/_shared/review-winery/review-winery.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Winery, WineryReview } from 'src/app/_types';
+
+@Component({
+  selector: 'app-review-winery',
+  templateUrl: './review-winery.component.html',
+  styleUrls: ['./review-winery.component.sass']
+})
+export class ReviewWineryComponent {
+  rating: number = 1;
+  review: string = "";
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: Winery,
+    private dialogRef: MatDialogRef<ReviewWineryComponent>
+  ) {
+
+  }
+
+  onCancel() {
+    this.dialogRef.close();
+  }
+  onReview() {
+    const data: WineryReview = {
+      points: this.rating,
+      review: this.review,
+      winery_id: this.data.winery_id
+    }
+    this.dialogRef.close(data);
+  }
+
+}

--- a/frontend/src/app/_shared/shared.module.ts
+++ b/frontend/src/app/_shared/shared.module.ts
@@ -20,6 +20,8 @@ import { WineTypeComponent } from './wine-type/wine-type.component';
 import { ReviewWineryComponent } from './review-winery/review-winery.component';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSliderModule } from '@angular/material/slider';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { ReviewWineComponent } from './review-wine/review-wine.component';
 
 @NgModule({
   declarations: [
@@ -28,7 +30,8 @@ import { MatSliderModule } from '@angular/material/slider';
     WineryComponent,
     WineComponent,
     WineTypeComponent,
-    ReviewWineryComponent
+    ReviewWineryComponent,
+    ReviewWineComponent
   ],
   imports: [
     CommonModule,
@@ -43,7 +46,8 @@ import { MatSliderModule } from '@angular/material/slider';
     MatCardModule,
     MatDividerModule,
     MatIconModule,
-    MatSliderModule
+    MatSliderModule,
+    MatCheckboxModule,
   ],
 
   exports: [

--- a/frontend/src/app/_shared/shared.module.ts
+++ b/frontend/src/app/_shared/shared.module.ts
@@ -17,6 +17,9 @@ import { WineComponent } from './wine/wine.component';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
 import { WineTypeComponent } from './wine-type/wine-type.component';
+import { ReviewWineryComponent } from './review-winery/review-winery.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSliderModule } from '@angular/material/slider';
 
 @NgModule({
   declarations: [
@@ -24,7 +27,8 @@ import { WineTypeComponent } from './wine-type/wine-type.component';
     WineEditorComponent,
     WineryComponent,
     WineComponent,
-    WineTypeComponent
+    WineTypeComponent,
+    ReviewWineryComponent
   ],
   imports: [
     CommonModule,
@@ -37,7 +41,9 @@ import { WineTypeComponent } from './wine-type/wine-type.component';
     MatButtonModule,
     MatSelectModule,
     MatCardModule,
-    MatDividerModule
+    MatDividerModule,
+    MatIconModule,
+    MatSliderModule
   ],
 
   exports: [
@@ -45,7 +51,8 @@ import { WineTypeComponent } from './wine-type/wine-type.component';
     WineEditorComponent,
     WineryComponent,
     WineComponent,
-    WineTypeComponent
+    WineTypeComponent,
+
   ],
 })
 export class SharedModule { }

--- a/frontend/src/app/_shared/wine/wine.component.html
+++ b/frontend/src/app/_shared/wine/wine.component.html
@@ -8,4 +8,7 @@
         <p>{{ wine.price }}</p>
         <p>{{ wine.description}}</p>
     </mat-card-content>
+    <mat-card-actions>
+      <button mat-stroked-button (click)="reviewMe()">Write a review</button>
+    </mat-card-actions>
 </mat-card>

--- a/frontend/src/app/_shared/wine/wine.component.ts
+++ b/frontend/src/app/_shared/wine/wine.component.ts
@@ -1,13 +1,28 @@
 import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { WineService } from 'src/app/_services/wine.service';
 import { Wine } from 'src/app/_types';
+import { ReviewWineComponent } from '../review-wine/review-wine.component';
 
 @Component({
-  selector: 'app-wine',   
+  selector: 'app-wine',
   templateUrl: './wine.component.html',
   styleUrls: ['./wine.component.sass']
 })
 export class WineComponent{
   @Input() wine!: Wine;
 
-  constructor() { }
+  constructor(
+    private dialog: MatDialog,
+    private wineService: WineService
+  ) { }
+  reviewMe() {
+    this.dialog.open(ReviewWineComponent, {
+      data: this.wine
+    }).afterClosed().subscribe(data => {
+      if(!data) return;
+      console.log(data);
+      this.wineService.review(data).subscribe();
+    });
+  }
 }

--- a/frontend/src/app/_shared/winery/winery.component.html
+++ b/frontend/src/app/_shared/winery/winery.component.html
@@ -17,6 +17,8 @@
     <mat-divider></mat-divider>
   </mat-card-content>
   <mat-card-footer id="footer">
+    <button mat-stroked-button (click)="reviewMe()">Write a review</button>
+    <span class="spacer"></span>
     <mat-card-subtitle>
       {{winery.location}}, {{winery.region}} {{winery.country}}
     </mat-card-subtitle>

--- a/frontend/src/app/_shared/winery/winery.component.sass
+++ b/frontend/src/app/_shared/winery/winery.component.sass
@@ -10,3 +10,12 @@
   display: flex
   align-items: center
   justify-content: end
+  flex-wrap: wrap
+  gap: 1rem
+
+#footer button
+  width: fit-content
+
+.spacer
+  flex-grow: 1
+

--- a/frontend/src/app/_shared/winery/winery.component.ts
+++ b/frontend/src/app/_shared/winery/winery.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { WineryService } from 'src/app/_services/winery.service';
 import { Winery } from 'src/app/_types';
+import { ReviewWineryComponent } from '../review-winery/review-winery.component';
 
 @Component({
   selector: 'app-winery',
@@ -9,5 +12,16 @@ import { Winery } from 'src/app/_types';
 export class WineryComponent {
   @Input() winery!: Winery;
 
-  constructor() { }
+  constructor(
+    private dialog: MatDialog,
+    private wineryService: WineryService
+  ) { }
+  reviewMe() {
+    this.dialog.open(ReviewWineryComponent, {
+      data: this.winery
+    }).afterClosed().subscribe(data => {
+      if(!data) return;
+      this.wineryService.review(data).subscribe();
+    });
+  }
 }

--- a/frontend/src/app/_types/wine.interface.ts
+++ b/frontend/src/app/_types/wine.interface.ts
@@ -12,7 +12,7 @@ export enum WineType {
 }
 
 export interface Wine {
-  id: number,
+  wine_id: number,
   name: string,
   description: string,
   type: WineType,
@@ -30,4 +30,10 @@ export namespace WineType {
   export function valueOf(str: string) {
     return reverseMap.get(str);
   }
+}
+export interface WineReview {
+  wine_id: number,
+  drunk: boolean,
+  points: number,
+  review: string
 }

--- a/frontend/src/app/_types/winery.interface.ts
+++ b/frontend/src/app/_types/winery.interface.ts
@@ -9,3 +9,9 @@ export interface Winery {
   website: string,
 }
 
+
+export interface WineryReview {
+  winery_id: number
+  points: number,
+  review: string,
+}

--- a/frontend/src/app/admin/wine-table/wine-table-datasource.ts
+++ b/frontend/src/app/admin/wine-table/wine-table-datasource.ts
@@ -56,12 +56,12 @@ export class WineTableDataSource extends DataSource<Wine> {
   }
   updateWine(wine: Wine) {
     this.data.next(this.data.value.map(elem => {
-      if(elem.id != wine.id) return elem;
+      if(elem.wine_id != wine.wine_id) return elem;
       return wine;
     }));
   }
   removeWine(wine: Wine) {
-    this.data.next(this.data.value.filter(elem => elem.id != wine.id));
+    this.data.next(this.data.value.filter(elem => elem.wine_id != wine.wine_id));
   }
 
   /**

--- a/frontend/src/styles.sass
+++ b/frontend/src/styles.sass
@@ -17,7 +17,7 @@ body
 
 .Wines
    display: grid
-   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr))
+   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr))
    grid-gap: 20px
    padding: 1rem
 


### PR DESCRIPTION
I have added wine & winery review buttons to the cards with their respective implementations. Currently, `WineService` and `WineryService` use an old version of the API that requires a `user_id` to be specified, but later implementations remove this restriction, getting `user_id` from the API key